### PR TITLE
Remove about page and folder

### DIFF
--- a/src/routes/About/+page.svelte
+++ b/src/routes/About/+page.svelte
@@ -1,1 +1,0 @@
-<h1>Hello World</h1>


### PR DESCRIPTION
This page and folder was added by mistake by me @SchoolyB in the Initial commit. There was no `v0.1` plan for an about page so there is no need in having the file right now. 